### PR TITLE
Add validation and service wiring for lexicon generator command

### DIFF
--- a/bootstrap/container.php
+++ b/bootstrap/container.php
@@ -45,7 +45,7 @@ return (function () {
 
     // Set up the container
     $container = new ContainerBuilder();
-    $container->set(ClassLoader::class, $classLoader);
+    $container->set('loader', $classLoader);
     $container->set(ConfigManager::class, $configManager);
 
     // Add config as container parameter

--- a/config/codegen.php
+++ b/config/codegen.php
@@ -1,16 +1,11 @@
 <?php
 
 return [
-    'namespaces' => [
-        'default' => [
-            'namespace' => 'App\\Generated',
-            'path' => 'src/Generated'
-        ]
+    'lexicons' => [
+//        'source' => __DIR__ . "/../atproto/lexicons",
     ],
-    "lexicons" => [
-        'source' => __DIR__ . "/../atproto/lexicons"
-    ],
+
     'output' => [
-        'path' => __DIR__ . "/../output"
-    ]
+        'base_namespace' => "GeneratedLexicons\\",
+    ],
 ];

--- a/config/services.php
+++ b/config/services.php
@@ -3,7 +3,11 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Blugen\Config\ConfigManager;
+use Blugen\Service\Lexicon\GeneratorInterface;
+use Blugen\Service\Lexicon\ReaderInterface;
+use Blugen\Service\Lexicon\V1\Generator as LexiconGenerator;
 use Blugen\Service\Lexicon\V1\Nsid;
+use Blugen\Service\Lexicon\V1\Reader;
 use Composer\Autoload\ClassLoader;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -16,4 +20,12 @@ return static function (ContainerConfigurator $container): void {
 
     $services->set(ClassLoader::class)->public();
     $services->set(ConfigManager::class)->public();
+
+    $services->set(Reader::class)
+        ->alias(ReaderInterface::class, Reader::class)
+        ->public();
+
+    $services->set(LexiconGenerator::class)
+        ->alias(GeneratorInterface::class, LexiconGenerator::class)
+        ->public();
 };

--- a/src/Command/Generate.php
+++ b/src/Command/Generate.php
@@ -4,12 +4,19 @@ namespace Blugen\Command;
 
 use Blugen\Config\ConfigManager;
 use Blugen\Container;
+use Blugen\Service\Lexicon\GeneratorInterface;
+use InvalidArgumentException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\Collection;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Symfony\Component\Validator\Validation;
 
 class Generate extends Command
 {
@@ -30,71 +37,82 @@ class Generate extends Command
                 "s",
                 InputOption::VALUE_OPTIONAL,
                 "Lexicon(s) source: directory or direct path of a lexicon",
+            )
+            ->addOption(
+                "base-namespace",
+                "bn",
+                InputOption::VALUE_OPTIONAL,
+                "Base namespace for the lexicons to be generated",
             );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
-        $io->title('Blugen Code Generator');
 
-        // Source option
-        $source = $input->getOption('source') ?? $this->configManager->get('lexicons.source');
-
-        if (! file_exists($source)) {
-            $io->error(sprintf("Source file '%s' does not exist", $source));
+        try {
+            $options = $this->options($input);
+            $this->configManager->set('lexicons.source', $options['source']);
+            $this->configManager->set('output.base_namespace', $options['base-namespace']);
+        } catch (InvalidArgumentException $e) {
+            $io->error($e->getMessage());
             return Command::FAILURE;
         }
 
-        if (! is_readable($source)) {
-            $io->error(sprintf("Source file '%s' is not readable", $source));
-            return Command::FAILURE;
-        }
-
-        $this->configManager->set("lexicons.source", $source);
-
-        // Load configuration values
-        $outputDir = $this->configManager->get('output.path');
-        $namespaces = $this->configManager->get('namespaces');
-        $sourcePath = $this->configManager->get('lexicons.source');
-
-        // Show configuration summary
-        $io->section('Configuration');
-        $io->table(
-            ['Setting', 'Value'],
-            [
-                ['Output Directory', $outputDir],
-                ['Default Namespace', $namespaces['default']['namespace']],
-                ['Lexicon Source', $sourcePath],
-            ]
-        );
-
-        // Code generation would happen here
-        $io->section('Generating Code');
-        $io->progressStart(3); // Example: assume we have 3 steps
-
-        sleep(1);
-
-        // Step 1: Parse lexicons
-        $io->progressAdvance();
-        $io->text('✓ Parsed lexicon definitions');
-
-        sleep(1);
-
-        // Step 2: Generate classes
-        $io->progressAdvance();
-        $io->text('✓ Generated class files');
-
-        // Step 3: Write to disk
-        $io->progressAdvance();
-        $io->text('✓ Written files to disk');
-
-        sleep(1);
-
-        $io->progressFinish();
-
-        $io->success('Code generation completed successfully!');
+        /** @var GeneratorInterface $generator */
+        $generator = \container()->get(GeneratorInterface::class);
+        $generated = $generator->generate();
 
         return Command::SUCCESS;
+    }
+
+    private function options(InputInterface $input): array
+    {
+        $options = [
+            'source' => (string) $input->getOption('source') ?? $this->configManager->get('lexicons.source'),
+            'base-namespace' => (string) $input->getOption('base-namespace') ?? $this->configManager->get('output.base_namespace'),
+        ];
+
+        $violations = $this->validate($options);
+
+        if (count($violations) > 0) {
+            throw new InvalidArgumentException("Validation failed:\n\n" . $violations->__toString());
+        }
+
+        return $options;
+    }
+
+    private function validate(array $options): ConstraintViolationListInterface
+    {
+        $validator = Validation::createValidator();
+
+        $loader = container()->get('loader');
+
+        return $validator->validate($options, new Collection([
+            'source' => [
+                new NotBlank(),
+                new Callback(function ($value, $context) {
+                    if (!file_exists($value)) {
+                        $context->buildViolation("Path '{{ value }}' does not exist.")
+                            ->setParameter('{{ value }}', $value)
+                            ->addViolation();
+                    } elseif (!is_readable($value)) {
+                        $context->buildViolation("Path '{{ value }}' is not readable.")
+                            ->setParameter('{{ value }}', $value)
+                            ->addViolation();
+                    }
+                }),
+            ],
+            'base-namespace' => [
+                new NotBlank(),
+                new Callback(function ($value, $context) use ($loader) {
+                    if (!isset($loader->getPrefixesPsr4()[$value])) {
+                        $context->buildViolation("Namespace '{{ value }}' is not registered in PSR-4 loader.")
+                            ->setParameter('{{ value }}', $value)
+                            ->addViolation();
+                    }
+                }),
+            ]
+        ]));
     }
 }

--- a/src/Service/Lexicon/V1/Reader.php
+++ b/src/Service/Lexicon/V1/Reader.php
@@ -2,16 +2,22 @@
 
 namespace Blugen\Service\Lexicon\V1;
 
+use Blugen\Config\ConfigManager;
 use Blugen\Service\Lexicon\ReaderInterface;
 use RuntimeException;
 
 class Reader implements ReaderInterface
 {
     private array $paths = [];
+    private readonly ConfigManager $config;
+    private readonly ?string $path;
 
     public function __construct(
-        private readonly ?string $path = null
+        ?string $path = null,
+        ?ConfigManager $config = null,
     ) {
+        $this->config = $config ?? container()->get(ConfigManager::class);
+        $this->path = (string) ($path ?? $this->config->get('lexicons.source'));
     }
 
     public function read(?string $path = null): static


### PR DESCRIPTION
- Registered Reader and Generator services with explicit interfaces
- Added Symfony Validator integration to validate CLI options:
  - 'source' must exist and be readable
  - 'base-namespace' must be defined in PSR-4 autoloader
- Enhanced Generate command to validate, apply config, and trigger code generation
- Refactored Reader to resolve path from ConfigManager when not explicitly provided
