### PR TITLE
Refactor code generation to output separate classes for schemas and params

### DIFF
--- a/src/Command/Generate.php
+++ b/src/Command/Generate.php
@@ -61,15 +61,17 @@ class Generate extends Command
 
         /** @var GeneratorInterface $generator */
         $generator = \container()->get(GeneratorInterface::class);
+        $generated = $generator->generate();
 
-        foreach($generator->generate() as $path => $content) {
-            $dirname = dirname($path);
-
-            if (! file_exists($dirname)) {
-                mkdir($dirname, 0755, true);
+        foreach($generated as $path => $content) {
+            if (! file_exists($path)) {
+                mkdir($path, 0755, true);
             }
 
-            file_put_contents($path, $content);
+            foreach($content as $fileName => $class) {
+                $filePath = $path . DIRECTORY_SEPARATOR . $fileName;
+                file_put_contents($filePath, $class);
+            }
         }
 
         return Command::SUCCESS;

--- a/src/Service/Lexicon/V1/ComponentGenerator/Field/RefComponentGenerator.php
+++ b/src/Service/Lexicon/V1/ComponentGenerator/Field/RefComponentGenerator.php
@@ -31,8 +31,7 @@ class RefComponentGenerator implements GeneratorInterface
         $type = $this->phpType();
         $doc = $this->docType();
 
-        $this->class->getNamespace()
-            ?->addUse(trim($type, '?'));
+        $this->class->getNamespace()->addUse(trim($type, '?'));
 
         $this->class->addProperty($this->property->name())
             ->setPrivate()

--- a/src/Service/Lexicon/V1/DefGenerator/Primary/QueryGenerator.php
+++ b/src/Service/Lexicon/V1/DefGenerator/Primary/QueryGenerator.php
@@ -9,6 +9,7 @@ use Blugen\Service\Lexicon\V1\Resolver\NamespaceResolver;
 use Blugen\Service\Lexicon\V1\TypeSpecificDefinition\Field\ObjectTypeDefinition;
 use Blugen\Service\Lexicon\V1\TypeSpecificDefinition\Primary\QueryTypeDefinition;
 use Nette\PhpGenerator\ClassType;
+use Nette\PhpGenerator\Literal;
 use Nette\PhpGenerator\PhpFile;
 use Nette\PhpGenerator\PhpNamespace;
 
@@ -17,28 +18,61 @@ class QueryGenerator implements GeneratorInterface
     private readonly PhpFile $file;
     private readonly PhpNamespace $namespace;
     private readonly ClassType $class;
+    private readonly string $namespaceString;
+    private readonly string $className;
 
     public function __construct(
         private readonly QueryTypeDefinition $definition
     )
     {
-        [$namespaceString, $className] = NamespaceResolver::namespace($this->definition->lexicon(), $this->definition);
+        [$this->namespaceString, $this->className] = NamespaceResolver::namespace($this->definition->lexicon(), $this->definition);
 
         $this->file = new PhpFile();
-        $this->namespace = $this->file->addNamespace($namespaceString);
-        $this->class = $this->namespace->addClass($className);
+        $this->namespace = $this->file->addNamespace($this->namespaceString);
+        $this->class = $this->namespace->addClass($this->className);
 
         $this->file->setStrictTypes();
     }
 
-    public function generate(): string
+    public function generate(): array
     {
+        $result = [];
+
         $this->class->addImplement(QueryInterface::class);
 
+        $paramsFile = new PhpFile();
+        $paramsFile->setStrictTypes();
+        $paramsPhpNamespace = $paramsFile->addNamespace($this->namespaceString);
+        $paramsClassName = "{$this->className}Params";
+        $paramsNamespace = sprintf("%s\\%s", $paramsPhpNamespace->getName(), $paramsClassName);
+        $paramsClass = $paramsPhpNamespace->addClass($paramsClassName);
+
+
         foreach ($this->definition->parameters()?->properties() ?? [] as $property) {
-            ComponentGeneratorFactory::create($this->class, $property)->generate();
+            ComponentGeneratorFactory::create($paramsClass, $property)->generate();
         }
 
-        return $this->file->__toString();
+        $this->class->addProperty(new Literal("params"))
+            ->setPrivate()
+            ->setType($paramsNamespace);
+
+        $this->class->addMethod(new Literal("setParams"))
+            ->setPublic()
+            ->setReturnType(new Literal("self"))
+            ->addBody(new Literal("\$this->params = \$params;\nreturn \$this;"))
+            ->addParameter(new Literal("params"))
+            ->setType($paramsNamespace);
+
+        $this->class->addMethod(new Literal("getParams"))
+            ->setPublic()
+            ->setReturnType($paramsNamespace)
+            ->addBody(new Literal("return \$this->params;"));
+
+        $this->namespace->addUse($paramsNamespace);
+
+        return [
+            "$this->className.php" => $this->file->__toString(),
+            "$paramsClassName.php" => $paramsFile->__toString(),
+        ];
     }
 }

--- a/src/Service/Lexicon/V1/Generator.php
+++ b/src/Service/Lexicon/V1/Generator.php
@@ -26,7 +26,13 @@ class Generator implements GeneratorInterface
                 $classPath = NamespaceResolver::path($lexicon, $definition);
                 $generatedClass = DefGeneratorFactory::create($definition)?->generate();
 
-                $generated[$classPath] = $generatedClass;
+                if (! is_array($generatedClass)) {
+                    $generatedClass = [basename($classPath) => $generatedClass];
+                }
+
+                $classPath = dirname($classPath);
+
+                $generated[$classPath] = array_merge($generated[$classPath] ?? [], $generatedClass);
             }
         }
 


### PR DESCRIPTION
- Updated `ProcedureGenerator` and `QueryGenerator` to return multiple named class files (e.g. main class and schema/params class).
- Modified `Generator` to properly merge multiple class outputs per lexicon definition.
- Refactored file writing in the `Generate` command to handle directory creation and iterate over file batches.
- Ensured consistent namespace and file path structure for modular output.
