### PR TITLE
Add GitHub CI workflows, issue templates, and contributing documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,53 @@
+name: 🐛 Bug Report
+description: Report a bug or unexpected behavior
+title: "[Bug]: "
+labels: ["bug"]
+assignees: ["shahmal1yev"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      placeholder: |
+        1. Run command '...'
+        2. Use lexicon file '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: input
+    id: php-version
+    attributes:
+      label: PHP Version
+      placeholder: "8.2.15"
+    validations:
+      required: true
+
+  - type: textarea
+    id: error-output
+    attributes:
+      label: Error Output
+      description: Any error messages
+      render: text
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Anything else relevant

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: ✨ Feature Request
+description: Suggest a new feature
+title: "[Feature]: "
+labels: ["enhancement"]
+assignees: ["shahmal1yev"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem would this solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: What would you like to see?
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: How would you use this feature?
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Anything else relevant

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+    assignees:
+      - "shahmal1yev"
+    ignore:
+      - dependency-name: "symfony/*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- Brief description of changes -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature  
+- [ ] Breaking change
+- [ ] Documentation
+
+## Testing
+
+- [ ] Tests pass (`vendor/bin/phpunit`)
+- [ ] Static analysis passes (`vendor/bin/phpstan analyse`)
+- [ ] Code generation works (`./bin/blugen generate`)
+
+## Checklist
+
+- [ ] Code follows PSR-12 standards
+- [ ] Added/updated tests as needed
+- [ ] No breaking changes (or documented)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,83 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, 1.x ]
+  pull_request:
+    branches: [ main, 1.x ]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ['8.1', '8.2', '8.3', '8.4']
+        include:
+          - php-version: '8.2'
+            coverage: true
+
+    name: PHP ${{ matrix.php-version }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: mbstring, json
+          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-composer-${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-${{ matrix.php-version }}-
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+
+      - name: Run PHPStan
+        run: vendor/bin/phpstan analyse
+
+      - name: Run tests
+        run: |
+          if [ "${{ matrix.coverage }}" = "true" ]; then
+            vendor/bin/phpunit --coverage-clover coverage.xml
+          else
+            vendor/bin/phpunit
+          fi
+
+      - name: Test code generation
+        run: ./bin/blugen generate --help
+
+      - name: Upload coverage
+        if: matrix.coverage
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          fail_ci_if_error: false
+
+  security:
+    runs-on: ubuntu-latest
+    name: Security Check
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+
+      - name: Run security audit
+        run: composer audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse
+        run: vendor/bin/phpstan analyse --error-format github src tests
 
       - name: Run tests
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2
+          extensions: mbstring, json
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+
+      - name: Run tests
+        run: |
+          vendor/bin/phpunit
+          vendor/bin/phpstan analyse
+
+      - name: Get version
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ steps.version.outputs.version }}
+          body: |
+            ## Installation
+            
+            ```bash
+            composer require corebranch/blugen:^${{ steps.version.outputs.version }}
+            ```
+          draft: false
+          prerelease: false

--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,6 @@
 
 # PHPUnit
 /app/phpunit.xml
-/phpunit.xml
 
 # Build data
 /build/

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 
 # PHPUnit
 /app/phpunit.xml
-/phpunit.xml
 
 # Build data
 /build/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing to Blugen
+
+Thanks for your interest in contributing!
+
+## Getting Started
+
+### Prerequisites
+- PHP 8.1+
+- Composer
+
+### Setup
+```bash
+git clone https://github.com/YOUR_USERNAME/blugen.git
+cd blugen
+composer install
+```
+
+### Verify Installation
+```bash
+./bin/blugen --version
+vendor/bin/phpunit
+vendor/bin/phpstan analyse
+```
+
+## Development Workflow
+
+1. **Create a branch**
+   ```bash
+   git checkout -b feature/your-feature
+   ```
+
+2. **Make changes**
+   - Follow PSR-12 coding standards
+   - Add tests for new functionality
+
+3. **Test your changes**
+   ```bash
+   vendor/bin/phpunit
+   vendor/bin/phpstan analyse
+   ./bin/blugen generate --help
+   ```
+
+4. **Submit a pull request**
+
+## Coding Standards
+
+- Follow PSR-12
+- Use strict typing
+- Add docblocks for public methods
+- Write tests for new code
+
+## Running Tests
+
+```bash
+# All tests
+vendor/bin/phpunit
+
+# With coverage
+vendor/bin/phpunit --coverage-html coverage/
+
+# Static analysis
+vendor/bin/phpstan analyse
+```
+
+## Submitting Issues
+
+Use the issue templates for bug reports and feature requests. Include:
+- PHP version
+- Steps to reproduce
+- Expected vs actual behavior
+
+## Questions?
+
+Open a GitHub issue or discussion.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,7 @@
+parameters:
+    level: 1
+    paths:
+        - src
+        - tests
+    excludePaths:
+        - src/helpers.php

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheDirectory=".phpunit.cache"
+         executionOrder="depends,defects"
+         requireCoverageMetadata="false"
+         beStrictAboutCoverageMetadata="false"
+         beStrictAboutOutputDuringTests="true"
+         displayDetailsOnPhpunitDeprecations="true"
+         failOnPhpunitDeprecation="true"
+         failOnRisky="true"
+         failOnWarning="true">
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source restrictDeprecations="true" restrictNotices="true" restrictWarnings="true">
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/Command/Generate.php
+++ b/src/Command/Generate.php
@@ -22,7 +22,7 @@ class Generate extends Command
 {
     private ConfigManager $configManager;
 
-    public function __construct(ConfigManager $configManager = null)
+    public function __construct(?ConfigManager $configManager = null)
     {
         parent::__construct();
         $this->configManager = $configManager ?? container()->get(ConfigManager::class);

--- a/src/Service/Lexicon/V1/Lexicon.php
+++ b/src/Service/Lexicon/V1/Lexicon.php
@@ -40,7 +40,7 @@ class Lexicon implements LexiconInterface
 
     public function description(): ?string
     {
-        return $this->lexicon['description'];
+        return $this->lexicon['description'] ?? null;
     }
 
     public function defs(): array

--- a/tests/Unit/Service/Lexicon/V1/DefinitionTest.php
+++ b/tests/Unit/Service/Lexicon/V1/DefinitionTest.php
@@ -41,7 +41,7 @@ class DefinitionTest extends TestCase
         ],
     ];
 
-    private function lexicon(array $defs = null): LexiconInterface
+    private function lexicon(?array $defs = null): LexiconInterface
     {
         $defs ??= self::$defs;
 


### PR DESCRIPTION
This PR sets up basic GitHub project automation and contribution tools:

* **CI Workflow**: Runs tests, static analysis, and code generation checks for PHP 8.1–8.4.
* **Release Workflow**: Automatically creates a GitHub release when a version tag is pushed.
* **Dependabot**: Weekly Composer and monthly GitHub Actions dependency updates.
* **Issue Templates**: Added forms for bug reports and feature requests.
* **Pull Request Template**: Checklist for consistent PR submissions.
* **Contributing Guide**: Instructions for setup, coding standards, testing, and how to contribute.
