### PR TITLE
Increase test coverage of `Definition` and `Lexicon` components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -70,6 +72,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/src/Service/Lexicon/V1/Definition.php
+++ b/src/Service/Lexicon/V1/Definition.php
@@ -25,7 +25,7 @@ class Definition implements DefinitionInterface
             $name = 'main';
         }
 
-        return new self($lexicon, ltrim($name, '#'));
+        return new self($lexicon, str_starts_with($name, '#') ? substr($name, 1) : $name);
     }
 
     public function name(): string

--- a/src/Service/Lexicon/V1/Lexicon.php
+++ b/src/Service/Lexicon/V1/Lexicon.php
@@ -21,9 +21,20 @@ class Lexicon implements LexiconInterface
     public static function fromNsid(Nsid $nsid): LexiconInterface
     {
         $path = NsidResolver::path($nsid);
+        $nsid = $nsid->full();
+
+        if (! file_exists($path)) {
+            throw new \Error("The \"$nsid\" file does not exist: \"$path\"");
+        }
+
         $content = file_get_contents($path);
 
-        $toArray = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+        try {
+            $toArray = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            $realpath = realpath($path);
+            throw new \JsonException("The \"$nsid\" does not contain valid JSON: $realpath");
+        }
 
         return new Lexicon($toArray);
     }
@@ -35,7 +46,7 @@ class Lexicon implements LexiconInterface
 
     public function version(): int
     {
-        return $this->lexicon['version'];
+        return $this->lexicon['lexicon'];
     }
 
     public function description(): ?string

--- a/tests/Unit/Service/Lexicon/V1/DefinitionTest.php
+++ b/tests/Unit/Service/Lexicon/V1/DefinitionTest.php
@@ -2,10 +2,12 @@
 
 namespace Blugen\Tests\Unit\Service\Lexicon\V1;
 
+use Blugen\Service\Lexicon\DefinitionInterface;
 use Blugen\Service\Lexicon\LexiconInterface;
 use Blugen\Service\Lexicon\V1\Definition;
+use Blugen\Service\Lexicon\V1\Nsid;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
+use Blugen\Tests\TestCase;
 use InvalidArgumentException;
 
 class DefinitionTest extends TestCase
@@ -125,5 +127,40 @@ class DefinitionTest extends TestCase
         $this->expectExceptionMessage("Definition 'missingDef' does not exist in the lexicon.");
 
         new Definition($this->lexicon(), 'missingDef');
+    }
+
+    public function test_fromNsid_that_returns_definition_of_main_instance_by_nsid(): void
+    {
+        $nsid = new Nsid('app.bsky.actor.getProfile');
+        $definition = Definition::fromNsid($nsid);
+
+        $associativeArr = json_decode(
+            file_get_contents(__DIR__ . '/../../../../../atproto/lexicons/app/bsky/actor/getProfile.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+
+        $this->assertSame('main', $definition->name());
+        $this->assertSame($associativeArr['defs']['main']['description'], $definition->description());
+        $this->assertSame($associativeArr['defs']['main']['type'], $definition->type());
+        $this->assertSame($associativeArr['id'], $definition->lexicon()->nsid());
+    }
+
+    public function test_fromNsid_returns_definition_of_fragment_instance_by_nsid(): void
+    {
+        $nsid = new Nsid("app.bsky.actor.defs#knownFollowers");
+        $definition = Definition::fromNsid($nsid);
+
+        $associativeArr = json_decode(
+            file_get_contents(__DIR__ . '/../../../../../atproto/lexicons/app/bsky/actor/defs.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+
+        $this->assertSame('knownFollowers', $definition->name());
+        $this->assertSame($associativeArr['defs']['knownFollowers']['type'], $definition->type());
+        $this->assertSame($associativeArr['defs']['knownFollowers']['description'], $definition->description());
     }
 }

--- a/tests/Unit/Service/Lexicon/V1/LexiconTest.php
+++ b/tests/Unit/Service/Lexicon/V1/LexiconTest.php
@@ -2,17 +2,21 @@
 
 namespace Blugen\Tests\Unit\Service\Lexicon\V1;
 
+use Blugen\Config\ConfigManager;
 use Blugen\Service\Lexicon\V1\Lexicon;
+use Blugen\Service\Lexicon\V1\Nsid;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
+use Blugen\Tests\TestCase;
 use JsonException;
+use Exception;
+use TypeError;
 
 class LexiconTest extends TestCase
 {
     private function sampleLexiconArray(): array
     {
         return [
-            'version' => 1,
+            'lexicon' => 1,
             'id' => 'app.user.profile',
             'description' => 'Sample user profile lexicon.',
             'defs' => [
@@ -35,7 +39,7 @@ class LexiconTest extends TestCase
     public function test_it_accepts_json_and_array_on_construction(array $expectedArray, Lexicon $lexicon): void
     {
         $this->assertSame($expectedArray['id'], $lexicon->nsid());
-        $this->assertSame($expectedArray['version'], $lexicon->version());
+        $this->assertSame($expectedArray['lexicon'], $lexicon->version());
         $this->assertSame($expectedArray['description'], $lexicon->description());
         $this->assertSame($expectedArray['defs'], $lexicon->defs());
 
@@ -50,7 +54,7 @@ class LexiconTest extends TestCase
     public static function lexiconProvider(): array
     {
         $array = [
-            'version' => 1,
+            'lexicon' => 1,
             'id' => 'app.user.profile',
             'description' => 'Sample user profile lexicon.',
             'defs' => [
@@ -75,7 +79,7 @@ class LexiconTest extends TestCase
     public function test_description_can_be_null_if_not_set(): void
     {
         $array = [
-            'version' => 1,
+            'lexicon' => 1,
             'id' => 'app.minimal',
             'defs' => [],
         ];
@@ -83,5 +87,66 @@ class LexiconTest extends TestCase
         $lexicon = new Lexicon($array);
 
         $this->assertNull($lexicon->description());
+    }
+
+    public function test_fromNsid_parses_lexicon_from_a_nsid(): void
+    {
+        $nsid = new Nsid('app.bsky.actor.getProfile');
+        $lexicon = Lexicon::fromNsid($nsid);
+
+        $associativeArr = json_decode(
+            file_get_contents(__DIR__."/../../../../../atproto/lexicons/app/bsky/actor/getProfile.json"),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+
+        $this->assertSame($associativeArr['lexicon'], $lexicon->version());
+        $this->assertSame($associativeArr['id'], $lexicon->nsid());
+        $this->assertSame($associativeArr['description'] ?? null, $lexicon->description());
+        $this->assertSame($associativeArr['defs'], $lexicon->defs());
+    }
+
+    public function test_fromNsid_throws_not_found_exception_when_file_not_found(): void
+    {
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage("does not exist");
+
+        $nsid = new Nsid('nonexistent.lexicon');
+        Lexicon::fromNsid($nsid);
+    }
+
+    public function test_fromNsid_throws_invalid_json_exception_when_file_contains_invalid_json(): void
+    {
+        $this->expectException(JsonException::class);
+        $this->expectExceptionMessage("does not contain valid JSON");
+
+        $name = "temp_".uniqid();
+        $tempPath = sys_get_temp_dir().DIRECTORY_SEPARATOR."$name.json";
+        file_put_contents($tempPath, "invalid");
+
+        container()->get(ConfigManager::class)->set('lexicons.source', dirname($tempPath));
+
+        try {
+            Lexicon::fromNsid(new Nsid($name));
+        } catch (\Throwable $e) {
+            unlink($tempPath);
+            throw $e;
+        }
+    }
+
+    public function test_construction_with_malformed_json_depth_exceeded(): void
+    {
+        $this->expectException(JsonException::class);
+        
+        $deeplyNested = str_repeat('[', 600) . '1' . str_repeat(']', 600);
+        new Lexicon($deeplyNested);
+    }
+
+    public function test_construction_with_non_array_after_json_decode(): void
+    {
+        $this->expectException(TypeError::class);
+        
+        new Lexicon('"not-an-array"');
     }
 }


### PR DESCRIPTION
## Summary

This PR increases test coverage of `Definition` and `Lexicon` components.

## Type of Change

- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation

## Testing

- [x] Tests pass (`vendor/bin/phpunit`)
- [x] Static analysis passes (`vendor/bin/phpstan analyse`)
- [ ] Code generation works (`./bin/blugen generate`)

## Checklist

- [x] Code follows PSR-12 standards
- [x] Added/updated tests as needed
- [x] No breaking changes (or documented)