### PR TITLE
Fix namespace resolution for partial NSID references

### DIFF
--- a/src/Service/Lexicon/V1/ComponentGenerator/Field/RefComponentGenerator.php
+++ b/src/Service/Lexicon/V1/ComponentGenerator/Field/RefComponentGenerator.php
@@ -3,7 +3,9 @@
 namespace Blugen\Service\Lexicon\V1\ComponentGenerator\Field;
 
 use Blugen\Service\Lexicon\GeneratorInterface;
+use Blugen\Service\Lexicon\LexiconInterface;
 use Blugen\Service\Lexicon\V1\Property;
+use Blugen\Service\Lexicon\V1\Resolver\NamespaceResolver;
 use Blugen\Service\Lexicon\V1\Resolver\NsidResolver;
 use Blugen\Service\Lexicon\V1\TypeSpecificSchema\Field\RefSchema;
 use Nette\PhpGenerator\ClassType;
@@ -15,6 +17,7 @@ class RefComponentGenerator implements GeneratorInterface
     public function __construct(
         private readonly ClassType $class,
         private readonly Property $property,
+        private readonly ?LexiconInterface $lexicon = null,
     ) {
         $this->schema = new RefSchema($this->property->schema());
     }
@@ -65,14 +68,27 @@ class RefComponentGenerator implements GeneratorInterface
 
     private function phpType(): string
     {
-        $resolved = NsidResolver::namespace($this->schema->ref());
+        $resolved = $this->resolveNamespace();
         return $this->property->isRequired() ? $resolved : '?' . $resolved;
     }
 
     private function docType(): string
     {
-        $resolved = NsidResolver::namespace($this->schema->ref());
-        return $this->property->isRequired() ? $resolved : "{$resolved}|null";
+        $resolved = $this->resolveNamespace();
+        return $this->property->isRequired() ? "\\$resolved" : "\\{$resolved}|null";
+    }
+
+    private function resolveNamespace(): string
+    {
+        $ref = $this->schema->ref();
+        
+        // If ref starts with "#", it's a partial reference that needs the current lexicon's NSID
+        if (str_starts_with($ref, '#') && $this->lexicon !== null) {
+            $ref = $this->lexicon->nsid() . $ref;
+        }
+        
+        $resolved = NsidResolver::namespace($ref);
+        return NamespaceResolver::prefixed(ltrim($resolved, "\\"));
     }
 
     private function description(): string

--- a/src/Service/Lexicon/V1/ComponentGenerator/Field/UnionComponentGenerator.php
+++ b/src/Service/Lexicon/V1/ComponentGenerator/Field/UnionComponentGenerator.php
@@ -4,6 +4,7 @@ namespace Blugen\Service\Lexicon\V1\ComponentGenerator\Field;
 
 use Blugen\Service\Lexicon\GeneratorInterface;
 use Blugen\Service\Lexicon\V1\Property;
+use Blugen\Service\Lexicon\V1\Resolver\NamespaceResolver;
 use Blugen\Service\Lexicon\V1\Resolver\NsidResolver;
 use Blugen\Service\Lexicon\V1\TypeSpecificSchema\Field\UnionSchema;
 use Nette\PhpGenerator\ClassType;
@@ -30,7 +31,10 @@ class UnionComponentGenerator implements GeneratorInterface
     private function generateProperty(): void
     {
         foreach ($this->schema->refs() as $ref) {
-            $this->class->getNamespace()?->addUse(NsidResolver::namespace("$ref"));
+            $resolved = NsidResolver::namespace("$ref");
+            $prefixed = NamespaceResolver::prefixed(ltrim($resolved, "\\"));
+
+            $this->class->getNamespace()?->addUse($prefixed);
         }
 
         $this->class->addProperty($this->property->name())

--- a/src/Service/Lexicon/V1/DefGenerator/Field/ObjectGenerator.php
+++ b/src/Service/Lexicon/V1/DefGenerator/Field/ObjectGenerator.php
@@ -41,7 +41,8 @@ class ObjectGenerator implements GeneratorInterface
                     new Schema($property),
                     in_array($name, $this->nullable(), true),
                     in_array($name, $this->required(), true),
-                )
+                ),
+                $this->definition->lexicon()
             )->generate();
         }
 

--- a/src/Service/Lexicon/V1/DefGenerator/Primary/ProcedureGenerator.php
+++ b/src/Service/Lexicon/V1/DefGenerator/Primary/ProcedureGenerator.php
@@ -76,7 +76,7 @@ class ProcedureGenerator implements GeneratorInterface
             $schemaClass->addImplement(InputInterface::class);
 
             foreach($schema->properties() as $property) {
-                ComponentGeneratorFactory::create($schemaClass, $property)->generate();
+                ComponentGeneratorFactory::create($schemaClass, $property, $this->definition->lexicon())->generate();
             }
 
             $this->class->addMethod("setSchema")

--- a/src/Service/Lexicon/V1/DefGenerator/Primary/QueryGenerator.php
+++ b/src/Service/Lexicon/V1/DefGenerator/Primary/QueryGenerator.php
@@ -54,7 +54,7 @@ class QueryGenerator implements GeneratorInterface
 
 
         foreach ($this->definition->parameters()?->properties() ?? [] as $property) {
-            ComponentGeneratorFactory::create($paramsClass, $property)->generate();
+            ComponentGeneratorFactory::create($paramsClass, $property, $this->definition->lexicon())->generate();
         }
 
         $this->class->addMethod(new Literal("setParams"))

--- a/src/Service/Lexicon/V1/DefGenerator/Primary/RecordGenerator.php
+++ b/src/Service/Lexicon/V1/DefGenerator/Primary/RecordGenerator.php
@@ -41,7 +41,7 @@ class RecordGenerator implements GeneratorInterface
     public function generate(): string
     {
         foreach ($this->definition->record()->properties() as $name => $property) {
-            ComponentGeneratorFactory::create($this->class, $property)->generate();
+            ComponentGeneratorFactory::create($this->class, $property, $this->definition->lexicon())->generate();
         }
 
         return $this->file->__toString();

--- a/src/Service/Lexicon/V1/DefGenerator/Primary/SubscriptionGenerator.php
+++ b/src/Service/Lexicon/V1/DefGenerator/Primary/SubscriptionGenerator.php
@@ -33,7 +33,7 @@ class SubscriptionGenerator implements GeneratorInterface
         $this->class->addImplement(SubscriptionInterface::class);
 
         foreach($this->definition->parameters()?->properties() as $property) {
-            ComponentGeneratorFactory::create($this->class, $property)->generate();
+            ComponentGeneratorFactory::create($this->class, $property, $this->definition->lexicon())->generate();
         }
 
         return $this->file->__toString();

--- a/src/Service/Lexicon/V1/Factory/ComponentGeneratorFactory.php
+++ b/src/Service/Lexicon/V1/Factory/ComponentGeneratorFactory.php
@@ -3,6 +3,7 @@
 namespace Blugen\Service\Lexicon\V1\Factory;
 
 use Blugen\Service\Lexicon\GeneratorInterface;
+use Blugen\Service\Lexicon\LexiconInterface;
 use Blugen\Service\Lexicon\V1\ComponentGenerator\Field\ArrayComponentGenerator;
 use Blugen\Service\Lexicon\V1\ComponentGenerator\Field\BooleanComponentGenerator;
 use Blugen\Service\Lexicon\V1\ComponentGenerator\Field\BytesComponentGenerator;
@@ -22,7 +23,7 @@ use Blugen\Service\Lexicon\V1\ComponentGenerator\Field\TokenComponentGenerator;
 
 class ComponentGeneratorFactory
 {
-    public static function create(ClassType $class, Property $property): GeneratorInterface
+    public static function create(ClassType $class, Property $property, ?LexiconInterface $lexicon = null): GeneratorInterface
     {
         $type = $property->schema()->type();
 
@@ -38,7 +39,7 @@ class ComponentGeneratorFactory
             'cid-link' => new CidLinkComponentGenerator($class, $property),
             'blob' => new BlobComponentGenerator($class, $property),
             'token' => new TokenComponentGenerator($class, $property),
-            'ref' => new RefComponentGenerator($class, $property),
+            'ref' => new RefComponentGenerator($class, $property, $lexicon),
             'union' => new UnionComponentGenerator($class, $property),
             'unknown' => new UnknownComponentGenerator($class, $property),
             default => throw new \RuntimeException("Unsupported type: $type"),


### PR DESCRIPTION
Resolves issue with partial NSIDs (like '#replyRef') not being properly resolved to full NSIDs, causing incorrect namespace imports without base namespace prefixes.

Changes:
- Add lexicon context to ComponentGeneratorFactory and RefComponentGenerator
- Implement partial NSID detection and full NSID reconstruction
- Apply proper base namespace prefixing via NamespaceResolver::prefixed()
- Update all generator callsites to pass lexicon context
- Fix UnionComponentGenerator to use proper namespace prefixing

Generated classes now have correct imports like:
use BlugenGenerator\App\Bsky\Feed\Post\ReplyRef

instead of:
use ReplyRef

## Summary

<!-- Brief description of changes -->

## Type of Change

- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation

## Testing

- [x] Tests pass (`vendor/bin/phpunit`)
- [x] Static analysis passes (`vendor/bin/phpstan analyse`)
- [x] Code generation works (`./bin/blugen generate`)

## Checklist

- [ ] Code follows PSR-12 standards
- [ ] Added/updated tests as needed
- [x] No breaking changes (or documented)

Fixes #20 