### PR TITLE
Prevent empty file generation for token definitions and filter enums to exclude cross-lexicon NSIDs

### DIFF
--- a/src/Service/Lexicon/V1/DefGenerator/Field/StringGenerator.php
+++ b/src/Service/Lexicon/V1/DefGenerator/Field/StringGenerator.php
@@ -56,6 +56,10 @@ class StringGenerator implements GeneratorInterface
 
     private function addEnumCase(string $value): void
     {
+        if (! $this->shouldInclude($value)) {
+            return;
+        }
+
         $caseInfo = $this->processCaseValue($value);
 
         $this->enum
@@ -127,5 +131,14 @@ class StringGenerator implements GeneratorInterface
         }
 
         return strtoupper($normalized);
+    }
+
+    private function shouldInclude(string $value): bool
+    {
+        if ($this->isReference($value)) {
+            return str_starts_with($value, $this->definition->lexicon()->nsid());
+        }
+
+        return true;
     }
 }

--- a/src/Service/Lexicon/V1/Generator.php
+++ b/src/Service/Lexicon/V1/Generator.php
@@ -24,7 +24,13 @@ class Generator implements GeneratorInterface
                 $definition = new Definition($lexicon, $definitionName);
 
                 $classPath = NamespaceResolver::path($lexicon, $definition);
-                $generatedClass = DefGeneratorFactory::create($definition)?->generate();
+                $generator = DefGeneratorFactory::create($definition);
+
+                if (is_null($generator)) {
+                    continue;
+                }
+
+                $generatedClass = $generator->generate();
 
                 if (! is_array($generatedClass)) {
                     $generatedClass = [basename($classPath) => $generatedClass];


### PR DESCRIPTION
## Summary

- Added `shouldInclude()` filter in `StringGenerator` to include only values belonging to the current lexicon.
- Updated `Generator` to skip definitions with no generator (e.g. token types), preventing creation of empty class files.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## Testing

- [x] Tests pass (`vendor/bin/phpunit`)
- [x] Static analysis passes (`vendor/bin/phpstan analyse`)
- [x] Code generation works (`./bin/blugen generate`)

## Checklist

- [x] Code follows PSR-12 standards
- [ ] Added/updated tests as needed
- [x] No breaking changes (or documented)

## Closes

- Fixes #32
