### PR TITLE
Feat(Syntax): Implement ArrayType constraint, validator, and related schema improvements

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -8,6 +8,8 @@ use Blugen\Service\Lexicon\ReaderInterface;
 use Blugen\Service\Lexicon\V1\Generator as LexiconGenerator;
 use Blugen\Service\Lexicon\V1\Nsid;
 use Blugen\Service\Lexicon\V1\Reader;
+use Blugen\Service\Syntax\Factory\ConstraintFactory;
+use Blugen\Service\Syntax\Factory\SchemaFactory;
 use Blugen\Service\Xrpc\Client;
 use Blugen\Service\Xrpc\ClientInterface;
 use Composer\Autoload\ClassLoader;
@@ -33,5 +35,11 @@ return static function (ContainerConfigurator $container): void {
 
     $services->set(Client::class)
         ->alias(ClientInterface::class, Client::class)
+        ->public();
+
+    $services->set(SchemaFactory::class)
+        ->public();
+
+    $services->set(ConstraintFactory::class)
         ->public();
 };

--- a/src/Service/Lexicon/V1/ComponentGenerator/Field/ArrayComponentGenerator.php
+++ b/src/Service/Lexicon/V1/ComponentGenerator/Field/ArrayComponentGenerator.php
@@ -79,8 +79,8 @@ class ArrayComponentGenerator implements GeneratorInterface, ArraySerializationC
             $lines[] = "@length " . ($min ?? '0') . '-' . ($max ?? '∞');
         }
 
-        if ($this->schema->items()) {
-            $lines[] = "@items " . $this->schema->items();
+        if ($itemsType = $this->schema->items()['type']) {
+            $lines[] = "@items " . $itemsType;
         }
 
         return $lines;
@@ -93,7 +93,7 @@ class ArrayComponentGenerator implements GeneratorInterface, ArraySerializationC
 
     private function docType(): string
     {
-        $itemType = $this->schema->items();
+        $itemType = $this->schema->items()['type'];
 
         $base = $itemType ? $itemType . '[]' : 'array';
 

--- a/src/Service/Lexicon/V1/TypeSpecificSchema/Field/ArraySchema.php
+++ b/src/Service/Lexicon/V1/TypeSpecificSchema/Field/ArraySchema.php
@@ -26,9 +26,9 @@ class ArraySchema implements SchemaInterface
         return $this->schema->description();
     }
 
-    public function items(): string
+    public function items(): array
     {
-        return $this->__get('items.type');
+        return $this->__get('items');
     }
 
     public function minLength(): ?int

--- a/src/Service/Syntax/Constraints/ArrayType/ArrayType.php
+++ b/src/Service/Syntax/Constraints/ArrayType/ArrayType.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Blugen\Service\Syntax\Constraints\ArrayType;
+
+use Attribute;
+use Blugen\Service\Syntax\Constraints\LexConstraint;
+use Symfony\Component\Validator\Constraint;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class ArrayType extends Constraint implements LexConstraint
+{
+    use \Blugen\Service\Syntax\Constraints\Constraint;
+
+    public string $invalidMessage = 'Array contains invalid items. Expected elements of type {{ type }}, but index {{ index }} has an invalid value.';
+    public string $invalidMaxLengthMessage = 'Array is too long. The maximum allowed number of items is {{ limit }}, but {{ actualCount }} given';
+    public string $invalidMinLengthMessage = 'Array is too short. The minimum required number of items is {{ limit }}, but {{ actualCount }} given';
+}

--- a/src/Service/Syntax/Constraints/ArrayType/ArrayTypeValidator.php
+++ b/src/Service/Syntax/Constraints/ArrayType/ArrayTypeValidator.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Blugen\Service\Syntax\Constraints\ArrayType;
+
+use Blugen\Service\Lexicon\SchemaInterface;
+use Blugen\Service\Lexicon\V1\Schema;
+use Blugen\Service\Lexicon\V1\TypeSpecificSchema\Field\ArraySchema;
+use Blugen\Service\Syntax\Constraints\LexConstraint;
+use Blugen\Service\Syntax\Factory\ConstraintFactory;
+use Blugen\Service\Syntax\Factory\SchemaFactory;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class ArrayTypeValidator extends ConstraintValidator
+{
+    private ArraySchema $schema;
+
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        $subContext = clone $this->context;
+
+        if (! $constraint instanceof ArrayType) {
+            throw new UnexpectedTypeException($constraint, ArrayType::class);
+        }
+
+        $this->schema = new ArraySchema(new Schema($constraint->schema()));
+
+        if (! is_array($value)) {
+            throw new UnexpectedTypeException($value, 'array');
+        }
+
+        if ($this->hasInvalidMinLength($value)) {
+            $this->context->buildViolation($constraint->invalidMinLengthMessage)
+                ->setParameter('{{ limit }}', $this->schema->minLength())
+                ->setParameter('{{ actualCount }}', count($value))
+                ->addViolation();
+        }
+
+        if ($this->hasInvalidMaxLength($value)) {
+            $this->context->buildViolation($constraint->invalidMaxLengthMessage)
+                ->setParameter('{{ limit }}', $this->schema->maxLength())
+                ->setParameter('{{ actualCount }}', count($value))
+                ->addViolation();
+        }
+
+        $itemsSchemaArr = $this->schema->items();
+        $itemsSchemaArr['type'] ??= null;
+
+        /** @var SchemaInterface $itemsSchema */
+        $itemsSchema = container()->get(SchemaFactory::class)::create($itemsSchemaArr['type'], $itemsSchemaArr);
+
+        /** @var LexConstraint&Constraint $subConstraint */
+        $subConstraint = container()->get(ConstraintFactory::class)::create($itemsSchema->type(), $itemsSchemaArr);
+        /** @var ConstraintValidator $subValidator */
+        $subValidator = new ($subConstraint->validatedBy());
+
+        foreach($value as $index => $item) {
+            $subValidator->initialize($subContext);
+
+            try {
+                $subValidator->validate($item, $subConstraint);
+            } catch (UnexpectedTypeException $e) {
+                $subContext->addViolation($e->getMessage());
+            }
+
+            if (0 < $subContext->getViolations()->count()) {
+                $this->context->buildViolation($constraint->invalidMessage)
+                    ->setParameter('{{ type }}', $this->formatValue($itemsSchema->type()))
+                    ->setParameter('{{ index }}', $index)
+                    ->addViolation();
+
+                break;
+            }
+        }
+    }
+
+    private function hasInvalidMaxLength(array $value): bool
+    {
+        if (is_null($maxLength = $this->schema->maxLength())) {
+            return false;
+        }
+
+        if (count($value) <= $maxLength) {
+            return false;
+        }
+
+        return true; // is invalid
+    }
+
+    private function hasInvalidMinLength(array $value): bool
+    {
+        if (is_null($minLength = $this->schema->minLength())) {
+            return false;
+        }
+
+        if (count($value) >= $minLength) {
+            return false;
+        }
+
+        return true; // is invalid
+    }
+}

--- a/src/Service/Syntax/Constraints/Constraint.php
+++ b/src/Service/Syntax/Constraints/Constraint.php
@@ -6,7 +6,7 @@ trait Constraint
 {
     public array $schema;
 
-    public function __construct(array $schema = [])
+    public function __construct(array $schema)
     {
         $options = ['schema' => $schema];
         parent::__construct($options);

--- a/src/Service/Syntax/Factory/ConstraintFactory.php
+++ b/src/Service/Syntax/Factory/ConstraintFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Blugen\Service\Syntax\Factory;
+
+use Blugen\Service\Syntax\Constraints\ArrayType\ArrayType;
+use Blugen\Service\Syntax\Constraints\BooleanType\BooleanType;
+use Blugen\Service\Syntax\Constraints\IntegerType\IntegerType;
+use Blugen\Service\Syntax\Constraints\LexConstraint;
+use Blugen\Service\Syntax\Constraints\NullType\NullType;
+use Blugen\Service\Syntax\Constraints\StringType\StringType;
+
+class ConstraintFactory
+{
+    public static function create(string $type, array $schema): LexConstraint
+    {
+        return new (match ($type) {
+            'string' => StringType::class,
+            'integer' => IntegerType::class,
+            'boolean' => BooleanType::class,
+            'array' => ArrayType::class,
+            'null' => NullType::class,
+
+            default => throw new \InvalidArgumentException("Not found a constraint for type '{$type}'"),
+        })($schema);
+    }
+}

--- a/src/Service/Syntax/Factory/SchemaFactory.php
+++ b/src/Service/Syntax/Factory/SchemaFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Blugen\Service\Syntax\Factory;
+
+use Blugen\Service\Lexicon\SchemaInterface;
+use Blugen\Service\Lexicon\V1\Schema;
+use Blugen\Service\Lexicon\V1\TypeSpecificSchema\Field\ArraySchema;
+use Blugen\Service\Lexicon\V1\TypeSpecificSchema\Field\BlobSchema;
+use Blugen\Service\Lexicon\V1\TypeSpecificSchema\Field\BooleanSchema;
+use Blugen\Service\Lexicon\V1\TypeSpecificSchema\Field\BytesSchema;
+use Blugen\Service\Lexicon\V1\TypeSpecificSchema\Field\CidLinkSchema;
+use Blugen\Service\Lexicon\V1\TypeSpecificSchema\Field\IntegerSchema;
+use Blugen\Service\Lexicon\V1\TypeSpecificSchema\Field\NullSchema;
+use Blugen\Service\Lexicon\V1\TypeSpecificSchema\Field\ObjectSchema;
+use Blugen\Service\Lexicon\V1\TypeSpecificSchema\Field\RefSchema;
+use Blugen\Service\Lexicon\V1\TypeSpecificSchema\Field\StringSchema;
+use Blugen\Service\Lexicon\V1\TypeSpecificSchema\Field\TokenSchema;
+use Blugen\Service\Lexicon\V1\TypeSpecificSchema\Field\UnionSchema;
+use Blugen\Service\Lexicon\V1\TypeSpecificSchema\Field\UnknownSchema;
+
+class SchemaFactory
+{
+    public static function create(string $type, array $schema): SchemaInterface
+    {
+        return new (match ($type) {
+            'string' => StringSchema::class,
+            'integer' => IntegerSchema::class,
+            'boolean' => BooleanSchema::class,
+            'array' => ArraySchema::class,
+            'null' => NullSchema::class,
+            'ref' => RefSchema::class,
+            'blob' => BlobSchema::class,
+            'bytes' => BytesSchema::class,
+            'cid-link' => CidLinkSchema::class,
+            'object' => ObjectSchema::class,
+            'token' => TokenSchema::class,
+            'union' => UnionSchema::class,
+            'unknown' => UnknownSchema::class,
+
+            default => throw new \InvalidArgumentException("Not found a type-specific schema for type '$type'"),
+        })(new Schema($schema));
+    }
+}

--- a/tests/Unit/Service/Syntax/Constraints/ArrayTypeTest.php
+++ b/tests/Unit/Service/Syntax/Constraints/ArrayTypeTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Blugen\Tests\Unit\Service\Syntax\Constraints;
+
+use Blugen\Service\Syntax\Constraints\ArrayType\ArrayType;
+use Blugen\Service\Syntax\Constraints\ArrayType\ArrayTypeValidator;
+use Blugen\Service\Syntax\Constraints\StringType\StringType;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+class ArrayTypeTest extends ConstraintValidatorTestCase
+{
+    protected function createValidator(): ArrayTypeValidator
+    {
+        return new ArrayTypeValidator();
+    }
+
+    public function test_throws_exception_when_value_is_not_array(): void
+    {
+        $this->expectException(UnexpectedTypeException::class);
+
+        $constraint = new ArrayType([
+            'type' => 'array',
+            'items' => ['type' => 'integer'],
+        ]);
+
+        $this->validator->validate('not-an-array', $constraint);
+    }
+
+    public function test_expects_array_type_constraint(): void
+    {
+        $this->expectException(UnexpectedTypeException::class);
+
+        // Using wrong constraint intentionally
+        $this->validator->validate([], new StringType());
+    }
+
+    public function test_valid_when_items_are_all_valid(): void
+    {
+        $constraint = new ArrayType([
+            'type' => 'array',
+            'items' => ['type' => 'integer'],
+        ]);
+
+        $this->validator->validate([1, 2, 3], $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function test_invalid_when_any_item_is_invalid_reports_index_and_type(): void
+    {
+        $constraint = new ArrayType([
+            'type' => 'array',
+            'items' => ['type' => 'integer'],
+        ]);
+
+        $this->validator->validate([1, 'oops', 3], $constraint);
+
+        $this->buildViolation($constraint->invalidMessage)
+            ->setParameter('{{ type }}', '"integer"')
+            ->setParameter('{{ index }}', 1)
+            ->assertRaised();
+    }
+
+    public function test_is_invalid_when_array_too_short(): void
+    {
+        $constraint = new ArrayType([
+            'type' => 'array',
+            'items' => ['type' => 'integer'],
+            'minLength' => 3,
+        ]);
+
+        $this->validator->validate([1, 2], $constraint);
+
+        $this->buildViolation($constraint->invalidMinLengthMessage)
+            ->setParameter('{{ limit }}', 3)
+            ->setParameter('{{ actualCount }}', 2)
+            ->assertRaised();
+    }
+
+    public function test_is_valid_when_length_equals_min(): void
+    {
+        $constraint = new ArrayType([
+            'type' => 'array',
+            'items' => ['type' => 'integer'],
+            'minLength' => 2,
+        ]);
+
+        $this->validator->validate([1, 2], $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function test_is_valid_when_length_greater_than_min(): void
+    {
+        $constraint = new ArrayType([
+            'type' => 'array',
+            'items' => ['type' => 'integer'],
+            'minLength' => 2,
+        ]);
+
+        $this->validator->validate([1, 2, 3], $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function test_is_invalid_when_array_too_long(): void
+    {
+        $constraint = new ArrayType([
+            'type' => 'array',
+            'items' => ['type' => 'integer'],
+            'maxLength' => 2,
+        ]);
+
+        $this->validator->validate([1, 2, 3], $constraint);
+
+        $this->buildViolation($constraint->invalidMaxLengthMessage)
+            ->setParameter('{{ limit }}', 2)
+            ->setParameter('{{ actualCount }}', 3)
+            ->assertRaised();
+    }
+
+    public function test_is_valid_when_length_equals_max(): void
+    {
+        $constraint = new ArrayType([
+            'type' => 'array',
+            'items' => ['type' => 'integer'],
+            'maxLength' => 3,
+        ]);
+
+        $this->validator->validate([1, 2, 3], $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function test_is_valid_when_length_less_than_max(): void
+    {
+        $constraint = new ArrayType([
+            'type' => 'array',
+            'items' => ['type' => 'integer'],
+            'maxLength' => 4,
+        ]);
+
+        $this->validator->validate([1, 2, 3], $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    #[DataProvider('invalidValueProvider')]
+    public function test_throws_type_exception_for_invalid_value_types(mixed $value): void
+    {
+        $this->expectException(UnexpectedTypeException::class);
+
+        $constraint = new ArrayType([
+            'type' => 'array',
+            'items' => ['type' => 'integer'],
+        ]);
+
+        $this->validator->validate($value, $constraint);
+    }
+
+    public static function invalidValueProvider(): array
+    {
+        return [
+            ['string'],
+            [1.5],
+            [1],
+            [new \stdClass()],
+            [null],
+            [true],
+            [false],
+        ];
+    }
+
+    public function test_can_validate_nested_arrays(): void
+    {
+        $constraint = new ArrayType([
+            'type' => 'array',
+            'items' => [
+                'type' => 'array',
+                'items' => ['type' => 'integer']
+            ],
+        ]);
+
+        $this->validator->validate([[1], [2], 3], $constraint);
+
+        $this->buildViolation($constraint->invalidMessage)
+            ->setParameter('{{ type }}', '"array"')
+            ->setParameter('{{ index }}', 2)
+            ->assertRaised();
+    }
+}

--- a/tests/Unit/Service/Syntax/Constraints/ArrayTypeTest.php
+++ b/tests/Unit/Service/Syntax/Constraints/ArrayTypeTest.php
@@ -33,7 +33,7 @@ class ArrayTypeTest extends ConstraintValidatorTestCase
         $this->expectException(UnexpectedTypeException::class);
 
         // Using wrong constraint intentionally
-        $this->validator->validate([], new StringType());
+        $this->validator->validate([], new StringType([]));
     }
 
     public function test_valid_when_items_are_all_valid(): void

--- a/tests/Unit/Service/Syntax/Constraints/BooleanTypeTest.php
+++ b/tests/Unit/Service/Syntax/Constraints/BooleanTypeTest.php
@@ -19,7 +19,7 @@ class BooleanTypeTest extends ConstraintValidatorTestCase
     #[DataProvider('validBooleanProvider')]
     public function test_valid_boolean_values(bool $value): void
     {
-        $constraint = new BooleanType();
+        $constraint = new BooleanType([]);
 
         $this->validator->validate($value, $constraint);
 
@@ -39,7 +39,7 @@ class BooleanTypeTest extends ConstraintValidatorTestCase
     {
         $this->expectException(UnexpectedTypeException::class);
 
-        $constraint = new BooleanType();
+        $constraint = new BooleanType([]);
         $this->validator->validate($invalidValue, $constraint);
     }
 
@@ -84,7 +84,7 @@ class BooleanTypeTest extends ConstraintValidatorTestCase
 
     public function test_false_value_is_valid(): void
     {
-        $constraint = new BooleanType();
+        $constraint = new BooleanType([]);
 
         $this->validator->validate(false, $constraint);
 
@@ -93,7 +93,7 @@ class BooleanTypeTest extends ConstraintValidatorTestCase
 
     public function test_true_value_is_valid(): void
     {
-        $constraint = new BooleanType();
+        $constraint = new BooleanType([]);
 
         $this->validator->validate(true, $constraint);
 

--- a/tests/Unit/Service/Syntax/Constraints/NullTypeTest.php
+++ b/tests/Unit/Service/Syntax/Constraints/NullTypeTest.php
@@ -18,7 +18,7 @@ class NullTypeTest extends ConstraintValidatorTestCase
 
     public function test_null_is_valid(): void
     {
-        $constraint = new NullType();
+        $constraint = new NullType([]);
 
         $this->validator->validate(null, $constraint);
 
@@ -30,7 +30,7 @@ class NullTypeTest extends ConstraintValidatorTestCase
     {
         $this->expectException(UnexpectedTypeException::class);
 
-        $constraint = new NullType();
+        $constraint = new NullType([]);
 
         $this->validator->validate($value, $constraint);
     }
@@ -51,6 +51,6 @@ class NullTypeTest extends ConstraintValidatorTestCase
     {
         $this->expectException(UnexpectedTypeException::class);
 
-        $this->validator->validate(null, new StringType());
+        $this->validator->validate(null, new StringType([]));
     }
 }

--- a/tests/Unit/Service/Syntax/Factory/ConstraintFactoryTest.php
+++ b/tests/Unit/Service/Syntax/Factory/ConstraintFactoryTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Blugen\Tests\Unit\Service\Syntax\Factory;
+
+use Blugen\Service\Syntax\Constraints\ArrayType\ArrayType;
+use Blugen\Service\Syntax\Constraints\BooleanType\BooleanType;
+use Blugen\Service\Syntax\Constraints\IntegerType\IntegerType;
+use Blugen\Service\Syntax\Constraints\NullType\NullType;
+use Blugen\Service\Syntax\Constraints\StringType\StringType;
+use Blugen\Service\Syntax\Factory\ConstraintFactory;
+use Blugen\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class ConstraintFactoryTest extends TestCase
+{
+    #[DataProvider('supportedTypes')]
+    public function test_can_create_constraint(string $type, string $expectedInstanceOf): void
+    {
+        $this->assertInstanceOf($expectedInstanceOf, ConstraintFactory::create($type, []));
+    }
+
+    public static function supportedTypes(): array
+    {
+        return [
+            ['string', StringType::class],
+            ['integer', IntegerType::class],
+            ['boolean', BooleanType::class],
+            ['array', ArrayType::class],
+            ['null', NullType::class],
+        ];
+    }
+
+    public function test_throws_exception_when_provided_unsupported_type(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Not found a constraint for type 'invalid-type'");
+
+        ConstraintFactory::create('invalid-type', []);
+    }
+
+    public function test_passes_schema_to_constraint(): void
+    {
+        $expected = ['schema-item-key' => 'schema-item'];
+
+        $this->assertSame($expected, ConstraintFactory::create('string', $expected)->schema());
+    }
+}

--- a/tests/Unit/Service/Syntax/Factory/SchemaFactoryTest.php
+++ b/tests/Unit/Service/Syntax/Factory/SchemaFactoryTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Blugen\Tests\Unit\Service\Syntax\Factory;
+
+use Blugen\Service\Lexicon\V1\TypeSpecificSchema\Field\ArraySchema;
+use Blugen\Service\Lexicon\V1\TypeSpecificSchema\Field\BlobSchema;
+use Blugen\Service\Lexicon\V1\TypeSpecificSchema\Field\BooleanSchema;
+use Blugen\Service\Lexicon\V1\TypeSpecificSchema\Field\BytesSchema;
+use Blugen\Service\Lexicon\V1\TypeSpecificSchema\Field\CidLinkSchema;
+use Blugen\Service\Lexicon\V1\TypeSpecificSchema\Field\IntegerSchema;
+use Blugen\Service\Lexicon\V1\TypeSpecificSchema\Field\NullSchema;
+use Blugen\Service\Lexicon\V1\TypeSpecificSchema\Field\ObjectSchema;
+use Blugen\Service\Lexicon\V1\TypeSpecificSchema\Field\StringSchema;
+use Blugen\Service\Lexicon\V1\TypeSpecificSchema\Field\TokenSchema;
+use Blugen\Service\Lexicon\V1\TypeSpecificSchema\Field\UnionSchema;
+use Blugen\Service\Lexicon\V1\TypeSpecificSchema\Field\UnknownSchema;
+use Blugen\Service\Syntax\Factory\SchemaFactory;
+use Blugen\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class SchemaFactoryTest extends TestCase
+{
+    #[DataProvider('supportedTypes')]
+    public function test_can_create_schema(string $type, string $expectedSchemaFQCN): void
+    {
+        $this->assertInstanceOf($expectedSchemaFQCN, SchemaFactory::create($type, []));
+    }
+
+    public static function supportedTypes(): \Generator
+    {
+        yield 'string schema' => ['string', StringSchema::class];
+        yield 'integer schema' => ['integer', IntegerSchema::class];
+        yield 'boolean schema' => ['boolean', BooleanSchema::class];
+        yield 'array schema' => ['array', ArraySchema::class];
+        yield 'null schema' => ['null', NullSchema::class];
+        yield 'object schema' => ['object', ObjectSchema::class];
+        yield 'blob schema' => ['blob', BlobSchema::class];
+        yield 'bytes schema' => ['bytes', BytesSchema::class];
+        yield 'cid-link schema' => ['cid-link', CidLinkSchema::class];
+        yield 'token schema' => ['token', TokenSchema::class];
+        yield 'union schema' => ['union', UnionSchema::class];
+        yield 'unknown schema' => ['unknown', UnknownSchema::class];
+    }
+
+    public function test_throws_exception_for_invalid_schema_name(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Not found a type-specific schema for type 'invalid-schema-name'");
+
+        SchemaFactory::create('invalid-schema-name', []);
+    }
+
+    public function test_passes_schema_arr_to_instance(): void
+    {
+        $expected = [
+            'ref 1',
+            'ref 0'
+        ];
+
+        $refSchema = SchemaFactory::create('union', ['type' => 'union', 'refs' => $expected]);
+
+        $this->assertInstanceOf(
+            UnionSchema::class,
+            $refSchema,
+            "Must be instance of " . UnionSchema::class
+        );
+
+        $this->assertSame($expected, $refSchema->refs());
+    }
+}


### PR DESCRIPTION
### Summary

This pull request introduces the `ArrayType` constraint and validator within the Syntax module, extending the schema system to handle array-based type validation. It also includes supporting factory registrations, unit tests, and a refactor to improve schema consistency.

### Changes

* Added `ArrayType` constraint class for array schema validation.
* Added `ArrayTypeValidator` with support for item type checks and length boundaries.
* Added unit tests for `ArrayType`, `ConstraintFactory`, and `SchemaFactory`.
* Registered new schema and constraint factories in the container.
* Refactored `BaseConstraint` to remove the default value of the `schema` parameter and mark it as required.
* Updated `ArraySchema::items()` to return an array instead of a string, exposing the full item definition.

### 🚨 Breaking Change

* `ArraySchema::items()` now returns an array instead of a string.
